### PR TITLE
Support batching metrics when writing to Kafka

### DIFF
--- a/monasca_api/conf/kafka.py
+++ b/monasca_api/conf/kafka.py
@@ -81,6 +81,12 @@ Default is to listen on partition 0
                 help='''
 Specify if received data should be simply dropped.
 This parameter is only for testing purposes
+'''),
+    cfg.IntOpt('max_metrics_per_batch', default=1000,
+               help='''
+The maximum number of metrics per payload sent to
+Kafka. Posts to the Monasca API which exceed this will
+be chunked into batches not exceeding this number.
 ''')
 ]
 

--- a/monasca_api/v2/reference/metrics.py
+++ b/monasca_api/v2/reference/metrics.py
@@ -64,8 +64,11 @@ class Metrics(metrics_api_v2.MetricsV2API):
                                                  str(ex))
 
     def _send_metrics(self, metrics):
+        batch_size = cfg.CONF.kafka.max_metrics_per_batch
         try:
-            self._message_queue.send_message(metrics)
+            for i in range(0, len(metrics), batch_size):
+                batch = metrics[i:i + batch_size]
+                self._message_queue.send_message(batch)
         except message_queue_exceptions.MessageQueueException as ex:
             LOG.exception(ex)
             raise falcon.HTTPServiceUnavailable('Service unavailable',


### PR DESCRIPTION
When a large post (> 10s of MB) is made to the Monasca API an attempt
is made to write these metrics to the metrics topic in Kafka. However, due to
the large size of the write, this can fail with a number of obscure errors
which depend on exactly how much data is written. This change supports
splitting the post into chunks so that they can be written to Kafka in
sequence. A default has been chosen so that the maximum write to Kafka
should be comfortably under 1MB.

A future extension could support splitting the post by size, rather than the
number of measurements. A better time to look at this may be after the
Python Kafka library has been upgraded.

Story: 2006059
Task: 34772
Change-Id: I588a9bc0a19cd02ebfb8c0c1742896f208941396
(cherry picked from commit 901e35e232be301df11b875e300215d153364d40)