### PR TITLE
Support time range to query dimension names/values

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -99,6 +99,7 @@
         MONASCA_PERSISTER_IMPLEMENTATION_LANG: python
         MONASCA_METRICS_DB: cassandra
         TEMPEST_PLUGINS: /opt/stack/monasca-tempest-plugin
+      tempest_test_regex: (?!.*\[.*\btimerange\b.*\])(^monasca_tempest_tests.tests.api)
 
 - job:
     name: monasca-tempest-python3-cassandra
@@ -111,6 +112,7 @@
         MONASCA_PERSISTER_IMPLEMENTATION_LANG: python
         MONASCA_METRICS_DB: cassandra
         TEMPEST_PLUGINS: /opt/stack/monasca-tempest-plugin
+      tempest_test_regex: (?!.*\[.*\btimerange\b.*\])(^monasca_tempest_tests.tests.api)
 
 - job:
     name: monasca-tempest-python2-java-cassandra
@@ -121,6 +123,7 @@
         MONASCA_PERSISTER_IMPLEMENTATION_LANG: java
         MONASCA_METRICS_DB: cassandra
         TEMPEST_PLUGINS: /opt/stack/monasca-tempest-plugin
+      tempest_test_regex: (?!.*\[.*\btimerange\b.*\])(^monasca_tempest_tests.tests.api)
 
 - job:
     name: monasca-tempest-python3-java-cassandra
@@ -133,6 +136,7 @@
         MONASCA_PERSISTER_IMPLEMENTATION_LANG: java
         MONASCA_METRICS_DB: cassandra
         TEMPEST_PLUGINS: /opt/stack/monasca-tempest-plugin
+      tempest_test_regex: (?!.*\[.*\btimerange\b.*\])(^monasca_tempest_tests.tests.api)
 
 
 - project:

--- a/docs/monasca-api-spec.md
+++ b/docs/monasca-api-spec.md
@@ -1229,6 +1229,8 @@ None.
 * tenant_id (string, optional, restricted) - Tenant ID to from which to get dimension values. This parameter can be used to get dimension values from a tenant other than the tenant the request auth token is scoped to. Usage of this query parameter is restricted to users with the monasca admin role, as defined in the monasca api configuration file, which defaults to `monasca-admin`.
 * metric_name (string(255), optional) - A metric name to filter dimension values by.
 * dimension_name (string(255), required) - A dimension name to filter dimension values by.
+* start_time (string, optional) - The start time in ISO 8601 combined date and time format in UTC.
+* end_time (string, optional) - The end time in ISO 8601 combined date and time format in UTC.
 * offset (string(255), optional) - The dimension values are returned in alphabetic order, and the offset is the dimension name after which to return in the next pagination request.
 * limit (integer, optional)
 
@@ -1291,6 +1293,8 @@ None.
 #### Query Parameters
 * tenant_id (string, optional, restricted) - Tenant ID from which to get dimension names. This parameter can be used to get dimension names from a tenant other than the tenant the request auth token is scoped to. Usage of this query parameter is restricted to users with the monasca admin role, as defined in the monasca api configuration file, which defaults to `monasca-admin`.
 * metric_name (string(255), optional) - A metric name to filter dimension names by.
+* start_time (string, optional) - The start time in ISO 8601 combined date and time format in UTC.
+* end_time (string, optional) - The end time in ISO 8601 combined date and time format in UTC.
 * offset (string(255), optional) - The dimension names are returned in alphabetic order, and the offset is the dimension name after which will return in the next pagination request.
 * limit (integer, optional)
 

--- a/monasca_api/common/repositories/cassandra/metrics_repository.py
+++ b/monasca_api/common/repositories/cassandra/metrics_repository.py
@@ -149,7 +149,13 @@ class MetricsRepository(metrics_repository.AbstractMetricsRepository):
         self.epoch = datetime.utcfromtimestamp(0)
 
     def list_dimension_values(self, tenant_id, region, metric_name,
-                              dimension_name):
+                              dimension_name, start_timestamp=None,
+                              end_timestamp=None):
+
+        if start_timestamp or end_timestamp:
+            # NOTE(brtknr): For more details, see story
+            # https://storyboard.openstack.org/#!/story/2006204
+            LOG.info("Scoping by timestamp not implemented for cassandra.")
 
         try:
             if metric_name:
@@ -177,7 +183,13 @@ class MetricsRepository(metrics_repository.AbstractMetricsRepository):
 
         return json_dim_value_list
 
-    def list_dimension_names(self, tenant_id, region, metric_name):
+    def list_dimension_names(self, tenant_id, region, metric_name,
+                             start_timestamp=None, end_timestamp=None):
+
+        if start_timestamp or end_timestamp:
+            # NOTE(brtknr): For more details, see story
+            # https://storyboard.openstack.org/#!/story/2006204
+            LOG.info("Scoping by timestamp not implemented for cassandra.")
 
         try:
             if metric_name:

--- a/monasca_api/common/repositories/influxdb/metrics_repository.py
+++ b/monasca_api/common/repositories/influxdb/metrics_repository.py
@@ -159,7 +159,8 @@ class MetricsRepository(metrics_repository.AbstractMetricsRepository):
         return query
 
     def _build_show_tag_values_query(self, metric_name, dimension_name,
-                                     tenant_id, region):
+                                     tenant_id, region, start_timestamp,
+                                     end_timestamp):
         from_with_clause = ''
         if metric_name:
             from_with_clause += ' from "{}"'.format(metric_name)
@@ -167,18 +168,21 @@ class MetricsRepository(metrics_repository.AbstractMetricsRepository):
         if dimension_name:
             from_with_clause += ' with key = "{}"'.format(dimension_name)
 
-        where_clause = self._build_where_clause(None, None, tenant_id, region)
+        where_clause = self._build_where_clause(None, None, tenant_id, region,
+                                                start_timestamp, end_timestamp)
 
         query = 'show tag values' + from_with_clause + where_clause
 
         return query
 
-    def _build_show_tag_keys_query(self, metric_name, tenant_id, region):
+    def _build_show_tag_keys_query(self, metric_name, tenant_id, region,
+                                   start_timestamp, end_timestamp):
         from_with_clause = ''
         if metric_name:
             from_with_clause += ' from "{}"'.format(metric_name)
 
-        where_clause = self._build_where_clause(None, None, tenant_id, region)
+        where_clause = self._build_where_clause(None, None, tenant_id, region,
+                                                start_timestamp, end_timestamp)
 
         query = 'show tag keys' + from_with_clause + where_clause
 
@@ -919,11 +923,14 @@ class MetricsRepository(metrics_repository.AbstractMetricsRepository):
         return int((dt - datetime(1970, 1, 1)).total_seconds() * 1000)
 
     def list_dimension_values(self, tenant_id, region, metric_name,
-                              dimension_name):
+                              dimension_name, start_timestamp=None,
+                              end_timestamp=None):
         try:
             query = self._build_show_tag_values_query(metric_name,
                                                       dimension_name,
-                                                      tenant_id, region)
+                                                      tenant_id, region,
+                                                      start_timestamp,
+                                                      end_timestamp)
             result = self.influxdb_client.query(query)
             json_dim_name_list = self._build_serie_dimension_values(
                 result, dimension_name)
@@ -932,10 +939,13 @@ class MetricsRepository(metrics_repository.AbstractMetricsRepository):
             LOG.exception(ex)
             raise exceptions.RepositoryException(ex)
 
-    def list_dimension_names(self, tenant_id, region, metric_name):
+    def list_dimension_names(self, tenant_id, region, metric_name,
+                             start_timestamp=None, end_timestamp=None):
         try:
             query = self._build_show_tag_keys_query(metric_name,
-                                                    tenant_id, region)
+                                                    tenant_id, region,
+                                                    start_timestamp,
+                                                    end_timestamp)
             result = self.influxdb_client.query(query)
             json_dim_name_list = self._build_serie_dimension_names(result)
             return json_dim_name_list

--- a/monasca_api/v2/reference/metrics.py
+++ b/monasca_api/v2/reference/metrics.py
@@ -292,18 +292,24 @@ class DimensionValues(metrics_api_v2.DimensionValuesV2API):
         dimension_name = helpers.get_query_param(req, 'dimension_name',
                                                  required=True)
         offset = helpers.get_query_param(req, 'offset')
+        start_timestamp = helpers.get_query_starttime_timestamp(req, False)
+        end_timestamp = helpers.get_query_endtime_timestamp(req, False)
         result = self._dimension_values(tenant_id, req.uri, metric_name,
-                                        dimension_name, offset, req.limit)
+                                        dimension_name, offset, req.limit,
+                                        start_timestamp, end_timestamp)
         res.body = helpers.to_json(result)
         res.status = falcon.HTTP_200
 
     def _dimension_values(self, tenant_id, req_uri, metric_name,
-                          dimension_name, offset, limit):
+                          dimension_name, offset, limit, start_timestamp,
+                          end_timestamp):
 
         result = self._metrics_repo.list_dimension_values(tenant_id,
                                                           self._region,
                                                           metric_name,
-                                                          dimension_name)
+                                                          dimension_name,
+                                                          start_timestamp,
+                                                          end_timestamp)
 
         return helpers.paginate_with_no_id(result, req_uri, offset, limit)
 
@@ -327,15 +333,21 @@ class DimensionNames(metrics_api_v2.DimensionNamesV2API):
         tenant_id = helpers.get_x_tenant_or_tenant_id(req, ['api:delegate'])
         metric_name = helpers.get_query_param(req, 'metric_name')
         offset = helpers.get_query_param(req, 'offset')
+        start_timestamp = helpers.get_query_starttime_timestamp(req, False)
+        end_timestamp = helpers.get_query_endtime_timestamp(req, False)
         result = self._dimension_names(tenant_id, req.uri, metric_name,
-                                       offset, req.limit)
+                                       offset, req.limit,
+                                       start_timestamp, end_timestamp)
         res.body = helpers.to_json(result)
         res.status = falcon.HTTP_200
 
-    def _dimension_names(self, tenant_id, req_uri, metric_name, offset, limit):
+    def _dimension_names(self, tenant_id, req_uri, metric_name, offset, limit,
+                         start_timestamp, end_timestamp):
 
         result = self._metrics_repo.list_dimension_names(tenant_id,
                                                          self._region,
-                                                         metric_name)
+                                                         metric_name,
+                                                         start_timestamp,
+                                                         end_timestamp)
 
         return helpers.paginate_with_no_id(result, req_uri, offset, limit)

--- a/releasenotes/notes/support-timerange-for-dimension-names-and-values-e5a2ba64700dcd0b.yaml
+++ b/releasenotes/notes/support-timerange-for-dimension-names-and-values-e5a2ba64700dcd0b.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Dimensions names and values can be scoped by a timerange which can make
+    dimension related queries to large databases much faster because only the
+    relevant shards are searched. Users that upgrade their Monasca Grafana
+    Datasource plugin to version 1.3.0 will benefit from this feature.


### PR DESCRIPTION
At present, dimensions are not scoped by time window, which makes
dimension related queries to large databases timeout because it searches
all of time instead of a time window specified on the grafana app.

This commit implements the server side changes required to scope the
search query by the time window specified on the app.

Change-Id: Ia760c6789ac0063b8a25e52c9e0c3cc3b790ad2d
Story: 2005204
Task: 35790
(cherry picked from commit 233ea9c51b9684953b1d603aea46aa1671ac4fc9)