### PR TITLE
Implement separate db per tenancy

### DIFF
--- a/doc/source/admin/index.rst
+++ b/doc/source/admin/index.rst
@@ -62,3 +62,28 @@ Provide the following alongside the story:
 2. The fingerprint shown in the error message.
 
 3. The output of ``monasca_db fingerprint --raw``.
+
+Time Series Databases Setup
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Enabling InfluxDB Time Series Index in existing deployments
+-----------------------------------------------------------
+
+If enabling TSI on an existing InfluxDB install please follow the instructions
+for migrating existing data here:
+https://docs.influxdata.com/influxdb/v1.7/administration/upgrading/#upgrading-influxdb-1-3-1-4-no-tsi-preview-to-1-7-x-tsi-enabled
+
+Database Per Tenant
+-------------------
+
+It is envisaged that separate database per tenant will be the default
+behaviour in a future release of Monasca. Not only would it make queries
+faster for tenants, it would also allow administrators to define
+retention policy per tenancy. To enable this, set
+`influxdb.db_per_tenant` to `True` in `monasca-{api,persister}` config
+(it defaults to `False` at the moment if not set).
+
+To migrate existing data to database per tenant, refer to README.rst
+under the following URL which also contains the Python script to
+facilitate migration:
+https://opendev.org/openstack/monasca-persister/src/branch/master/monasca_persister/tools/db-per-tenant/

--- a/monasca_api/conf/influxdb.py
+++ b/monasca_api/conf/influxdb.py
@@ -22,6 +22,10 @@ influxdb_opts = [
                help='''
 Database name where metrics are stored
 '''),
+    cfg.BoolOpt('db_per_tenant', default=False,
+                help='''
+Whether to use a separate database per tenant
+'''),
     cfg.HostAddressOpt('ip_address', default='127.0.0.1',
                        help='''
 IP address to Influxdb server

--- a/releasenotes/notes/influxdb-support-for-db-per-tenant-6ada0c3979de6df8.yaml
+++ b/releasenotes/notes/influxdb-support-for-db-per-tenant-6ada0c3979de6df8.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Configuration option `db_per_tenant` added for InfluxDB to allow
+    data points to be written to dedicated tenant database where the
+    `database_name` prefixes the tenant ID, e.g. monasca_tenantid.


### PR DESCRIPTION
At present, all time series are accumulated in the same database in
InfluxDB. This makes queries slow for tenants that have less data. This
patch enables the option to use separate database per tenancy.

This changeset implements the changes on monasca-api which handles read
requests to InfluxDB database.

It also updates the relevant docs providing link to the migration tool
which enables users to migrate their existing data to a database per
tenant model.

Conflicts:
	doc/source/admin/index.rst

Change-Id: I7de6e0faf069b889d3953583b29a876c3d82c62c
Story: 2006331
Task: 36073
(cherry picked from commit 967b918bae7a76b6ec37d7f95bd473ebbfedb284)