### PR TITLE
Support batching metrics when writing to Kafka

### DIFF
--- a/monasca_api/conf/kafka.py
+++ b/monasca_api/conf/kafka.py
@@ -64,7 +64,11 @@ kafka_opts = [
                 help='Enable legacy Kafka client. When set old version of '
                      'kafka-python library is used. Message format version '
                      'for the brokers should be set to 0.9.0.0 to avoid '
-                     'performance issues until all consumers are upgraded.')
+                     'performance issues until all consumers are upgraded.'),
+    cfg.IntOpt('queue_buffering_max_messages', default=1000,
+               help='The maximum number of metrics per payload sent to '
+                    'Kafka. Posts to the Monasca API which exceed this will '
+                    'be chunked into batches not exceeding this number.')
 ]
 
 kafka_group = cfg.OptGroup(name='kafka', title='kafka')

--- a/releasenotes/notes/support-configuring-kafka-post-size-4baa10353e859b8a.yaml
+++ b/releasenotes/notes/support-configuring-kafka-post-size-4baa10353e859b8a.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - A new config option, queue_buffering_max_messages, has been added to
+    support controlling the size of posts to Kafka from the Monasca API.


### PR DESCRIPTION
When a large post (> 10s of MB) is made to the Monasca API an attempt
is made to write these metrics to the metrics topic in Kafka. However, due to
the large size of the write, this can fail with a number of obscure errors
which depend on exactly how much data is written. This change supports
splitting the post into chunks so that they can be written to Kafka in
sequence. A default has been chosen so that the maximum write to Kafka
should be comfortably under 1MB.

A future extension could support splitting the post by size, rather than the
number of measurements. A better time to look at this may be after the
Python Kafka library has been upgraded.

Story: 2006059
Task: 34772
Change-Id: I588a9bc0a19cd02ebfb8c0c1742896f208941396
(cherry picked from commit 022cffe3e0553e39715a8ac6755eddf8eca0c1c8)