### PR TITLE
Pull upstream improvements and add kafka batching

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -96,6 +96,7 @@
 - job:
     name: monasca-tempest-python2-cassandra
     parent: monasca-tempest-base
+    voting: false
     vars:
       devstack_localrc:
         USE_PYTHON3: false

--- a/devstack/plugin.sh
+++ b/devstack/plugin.sh
@@ -1218,8 +1218,9 @@ function clean_monasca_agent {
 function install_nodejs {
 
     echo_summary "Install Node.js"
+    curl -sL https://deb.nodesource.com/setup_10.x | sudo bash -
 
-    apt_get install nodejs npm
+    apt_get install nodejs
     npm config set registry "http://registry.npmjs.org/"; \
     npm config set proxy "${HTTP_PROXY}"; \
     npm set strict-ssl false;
@@ -1245,8 +1246,7 @@ function install_monasca_grafana {
         git_timed clone $GRAFANA_REPO $GRAFANA_DIR --branch $GRAFANA_BRANCH --depth 1
     fi
 
-    # Is required to use python2.7 to build grafana because node-gyp support only python2
-    npm config set python /usr/bin/python2.7
+    npm config set python /usr/bin/python3
 
     cd "${MONASCA_BASE}"
 

--- a/monasca_api/conf/kafka.py
+++ b/monasca_api/conf/kafka.py
@@ -64,7 +64,11 @@ kafka_opts = [
                 help='Enable legacy Kafka client. When set old version of '
                      'kafka-python library is used. Message format version '
                      'for the brokers should be set to 0.9.0.0 to avoid '
-                     'performance issues until all consumers are upgraded.')
+                     'performance issues until all consumers are upgraded.'),
+    cfg.IntOpt('queue_buffering_max_messages', default=1000,
+               help='The maximum number of metrics per payload sent to '
+                    'Kafka. Posts to the Monasca API which exceed this will '
+                    'be chunked into batches not exceeding this number.')
 ]
 
 kafka_group = cfg.OptGroup(name='kafka', title='kafka')

--- a/releasenotes/notes/support-configuring-kafka-post-size-4baa10353e859b8a.yaml
+++ b/releasenotes/notes/support-configuring-kafka-post-size-4baa10353e859b8a.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - A new config option, queue_buffering_max_messages, has been added to
+    support controlling the size of posts to Kafka from the Monasca API.


### PR DESCRIPTION
Merge upstream improvements up to 3.2.0 into stackhpc/train and include kafka batched metrics patch.